### PR TITLE
Adaptation from old init_timer to new timer_setup

### DIFF
--- a/HW-3/P3/satya_module.c
+++ b/HW-3/P3/satya_module.c
@@ -16,7 +16,7 @@ static char *n = "Satya";
 static long time = 0; /*in seconds*/
 int count = 0;
 
-void myfunc(unsigned long s)
+void myfunc(struct timer_list * s)
 {
 	count++;
 	printk("My name is %s and count is %d\n", n, count);
@@ -36,9 +36,8 @@ void myfunc(unsigned long s)
 
 static void timer_init(void)
 {
-	init_timer(&mytimer);
-	mytimer.function = myfunc;
-	mytimer.data = 0;
+	timer_setup(&mytimer, myfunc, 0);
+
 	if(time == 0)
 	{
 		mytimer.expires = (unsigned long)(jiffies + HZ/2);


### PR DESCRIPTION
Hi, I replaced init_timer to timer_setup for the latest Linux kernel compatibility (5.6.3).
because of init_timer not existing right now.
References:
https://stackoverflow.com/a/53842823/5688267